### PR TITLE
Potential fix for code scanning alert no. 2: Incomplete URL substring sanitization

### DIFF
--- a/utils/reddit.ts
+++ b/utils/reddit.ts
@@ -82,9 +82,14 @@ export async function fetchSubredditImages(subreddit: string, limit: number = 10
  */
 function isImageUrl(url: string): boolean {
   const imageExtensions = ['.jpg', '.jpeg', '.png', '.gif', '.webp'];
-  return imageExtensions.some(ext => url.toLowerCase().endsWith(ext)) ||
-         url.includes('i.redd.it') ||
-         url.includes('i.imgur.com');
+  try {
+    const parsedUrl = new URL(url);
+    const allowedHosts = ['i.redd.it', 'i.imgur.com'];
+    return imageExtensions.some(ext => url.toLowerCase().endsWith(ext)) ||
+           allowedHosts.includes(parsedUrl.host);
+  } catch (e) {
+    return false;
+  }
 }
 
 /**
@@ -124,8 +129,8 @@ export async function getRandomSubredditImage(subreddit: string): Promise<Reddit
         url.endsWith('.jpeg') ||
         url.endsWith('.png') ||
         url.endsWith('.gif') ||
-        url.includes('i.imgur.com') ||
-        url.includes('i.redd.it')
+        new URL(url).host === 'i.imgur.com' ||
+        new URL(url).host === 'i.redd.it'
       )
     })
 


### PR DESCRIPTION
Potential fix for [https://github.com/EVE-KILL/Thessia/security/code-scanning/2](https://github.com/EVE-KILL/Thessia/security/code-scanning/2)

To fix the problem, we need to parse the URL and check the host value instead of using a substring check. This ensures that the host is exactly 'i.imgur.com' or 'i.redd.it' and not part of a longer, potentially malicious URL.

- Parse the URL using the `URL` constructor to extract the host.
- Check if the host is in the allowed list of hosts ('i.imgur.com' and 'i.redd.it').


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced image URL validation for improved reliability when determining valid image links by employing structured URL parsing and robust error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->